### PR TITLE
Edits to search method, broadcastability, and display

### DIFF
--- a/chat-plugins/animesearch.js
+++ b/chat-plugins/animesearch.js
@@ -1,5 +1,6 @@
 //Anime search by SilverTactic (Siiilver)
-//This script uses the anime database of hummingbird.me btw
+//This script searches for an anime based on a given query and displays results.
+//it uses the anime database of hummingbird.me btw
 "use strict";
 
 const fs = require('fs');
@@ -22,16 +23,16 @@ function search (query) {
 	return new Promise(function (resolve, reject) {
 		let formattedQuery = format(query);
 		if (animeCache.queries[formattedQuery]) return resolve(animeCache.queries[formattedQuery]);
-		let link = 'https://hummingbird.me/search.json?query=' + query + '&type=anime';
+		let link = 'https://hummingbird.me/search.json?query=' + query;
 		request(link, function (err, response, data) {
 			if (err || response.statusCode !== 200) return reject('Anime results for "' + query + '" were not found...');
 			data = JSON.parse(data);
-			//Uses exact match if found, uses first match otherwise
+			//displays exact match if found, displays first match otherwise
 			let firstMatch, exactMatch;
 			for (let i in data.search) {
 				let info = data.search[i];
 				if (info.type === 'anime') {
-					if (info.link === formattedQuery || format(info.title) === formattedQuery) {
+					if (info.link === formattedQuery || toId(info.title) === formattedQuery) {
 						exactMatch = i;
 						break;
 					}
@@ -59,6 +60,7 @@ function search (query) {
 					'<b>Status: </b>' + data.status + '<br>' +
 					(data.show_type !== 'TV' ? '<b>Show Type: </b>' + data.show_type + '<br>' : '') +
 					(data.episode_count ? '<b>Episode Count: </b>' + data.episode_count + '<br>' : '') +
+					'<b>Episode Duration: </b>' + data.episode_length + ' minutes<br>' +
 					'<b>Air Date: </b>' + data.started_airing + '<br>' +
 					'<b>Rating: </b>' + (data.community_rating ? Math.round(data.community_rating * 100) / 100 + ' on 5' : 'N/A') + '<br>' +
 					'<b>Genre(s): </b>' + data.genres.map(function (genre) { return genre.name }).join(', ') + '<br>' +
@@ -84,8 +86,8 @@ exports.commands = {
 	as: 'anime',
 	anime: function (target, room, user, connection, cmd) {
 		if (!this.canBroadcast()) return;
-		if (room.id !== 'animeandmanga') return this.errorReply("This command can only be used in the room \"Anime and Manga\"");
-		if (!target || !target.trim()) return this.errorReply("/anime [query] - Searches for an anime based on the given search query.");
+		if (this.broadcasting && room.id === 'lobby') return this.errorReply("This command cannot be broadcasted in the lobby.");
+		if (!target || !target.trim()) return this.sendReply('/' + cmd + ' [query] - Searches for an anime based on the given search query.');
 
 		search(target.trim()).then(function (response) {
 			this.sendReplyBox(response);


### PR DESCRIPTION
I advise you to clear the anime cache. The script'll automatically rewrite the .json file after a hotpatch if it's invalid.
Script now displays episode duration, and can be broadcasted anywhere outside of the lobby.