### PR TITLE
Fix Roomshop and improve error messages

### DIFF
--- a/chat-plugins/roomshop.js
+++ b/chat-plugins/roomshop.js
@@ -11,7 +11,6 @@
 // { 'roomid': { 'item1id': ['item1name', 'item1desc', 'item1price'], 'item2id': ['item2name', 'item2desc', 'item2price'] } }
 
 
-/*
 var fs = require('fs');
 
 const ITEM_CAP = 8; // maximum items a room shop can have
@@ -94,5 +93,3 @@ exports.commands = {
 		"/roomshop buy, [item] - Buys an item from the shop.",
 		"/roomshop - Displays a room's room shop."],
 };
-
-*/

--- a/chat-plugins/roomshop.js
+++ b/chat-plugins/roomshop.js
@@ -10,7 +10,6 @@
 // OBJECT STRUCTURE:
 // { 'roomid': { 'item1id': ['item1name', 'item1desc', 'item1price'], 'item2id': ['item2name', 'item2desc', 'item2price'] } }
 
-
 var fs = require('fs');
 
 const ITEM_CAP = 8; // maximum items a room shop can have
@@ -38,34 +37,40 @@ function getRoomShop (room) {
 }
 
 exports.commands = {
-	roomshop: function(target, room, user) {
-		if (!room.founder) return this.errorReply("This room is not designed to have a room shop.");
+	roomshop: function(target, room, user, connection, cmd, message) {
+		if (!room.founder || room.isOfficial) return this.errorReply("This room is not designed to have a room shop.");
+		if (!target || !target.trim()) {
+			if (!RoomShop[room.id] || Object.keys(RoomShop[room.id]).length < 1) return this.errorReply("This room does not have any items in it's room shop at this time.");
+			if (!this.runBroadcast()) return;
+			return this.sendReplyBox(getRoomShop(room));
+		}
 
 		target = target.split(',');
 		for (var u in target) target[u] = target[u].trim();
 		if (!RoomShop[room.id]) RoomShop[room.id] = {};
 		var RS = RoomShop[room.id];
-		switch (target[0]) {
+		switch (toId(target[0])) {
 			case 'add':
-				if (user.userid !== room.founder && (!room.isOfficial || user.group === ' ')) return this.errorReply("This room does not qualify to have a roomshop at this time.");
-				if (RS.length > ITEM_CAP) return this.errorReply("You cannot add any more items.");
+				if ((user.userid !== room.founder) && !this.can('declare')) return false;
+				if (RS.length > ITEM_CAP) return this.errorReply("You have reached the item cap of " + ITEM_CAP + " and cannot add any more items.");
 				var item = target[1], desc = target[2], price = target[3];
+				if (!item || !desc || !price) return this.sendReply("Usage: /roomshop add, [item], [description], [price] - Adds an item to the roomshop.");
 				if (item.lenth > 15) return this.errorReply("Item names cannot exceed 15 characters.");
 				if (desc.length > 200) return this.errorReply("Item descriptions cannot exceed 200 characters.");
-				if (isNaN(Number(price)) || price < 1 || ~price.indexOf('.') || price > 1000) return this.errorReply("The price must be a positive integer.");
-				if (!item || !desc || !price) return this.errorReply("Usage: /roomshop add, [item], [description], [price] - Adds an item to the roomshop.");
+				if (isNaN(price) || price < 1 || ~price.indexOf('.') || price > 1000) return this.errorReply("The item's price must be a positive integer, and cannot exceed 1000.");
 				RS[toId(item)] = [item, desc, Number(price)];
 				saveShop();
 				return this.sendReply("You have successfully added the item '" + item + "' to your room shop.");
 				break;
 			case 'remove':
-				if (user.userid !== room.founder && (!room.isOfficial || user.group === ' ')) return this.errorReply("This room does not qualify to have a roomshop at this time.");
+				if ((user.userid !== room.founder) && !this.can('declare')) return false;
+				if (!target[1]) return this.sendReply("Usage: /roomshop remove, [item] - Removes an item from the roomshop.");
 				var item = toId(target[1]);
-				if (!RS[item]) return this.errorReply("This item is not in the room's shop. Check spelling?");
+				if (!RS[item]) return this.errorReply("'" + target[1] + "' is not an item in the room shop. Check spelling?");
 				var itemName = RS[item][0];
 				delete RoomShop[room.id][item];
 				saveShop();
-				return this.sendReply("You have successfully removed the item '" + itemName + "' from the room's shop");
+				return this.sendReply("You have successfully removed the item '" + itemName + "' from the room's shop.");
 				break;
 			case 'buy':
 				var item = toId(target[1]);
@@ -73,7 +78,7 @@ exports.commands = {
 				if (!RS[item]) return this.errorReply("This item is not in the room shop. Check spelling?");
 				item = RS[item][0];
 				var price = RS[item][2];
-				if (economy.readMoney(user.userid) < price) return this.errorReply("You do not have enough bucks to do buy " + item + ". You need " + (price - economy.readMoney(user.userid)) + " more bucks to buy this item.");
+				if (economy.readMoney(user.userid) < price) return this.errorReply("You do not have enough bucks to buy " + item + ". You need " + (price - economy.readMoney(user.userid)) + " more bucks to buy this item.");
 				this.parse('/tb ' + room.founder + ', ' + price);
 				room.add("|raw|<b><u>Room Shop</u>: " + getName(user.name) + "</b> has bought a(n) <u>" + Tools.escapeHTML(item) + "</u> from the room shop for " + price + " buck" + (price > 1 ? "s" : "") + ".").update();
 				this.privateModCommand("(" + user.name + " has bought a(n) " + item + " from the room shop.)");
@@ -81,15 +86,19 @@ exports.commands = {
 			case 'help':
 				this.parse('/help roomshop');
 				break;
-			default:
-				if (!RoomShop[room.id] || Object.keys(RoomShop[room.id]).length < 1) return this.errorReply("This room does not have any items in it's room shop at this time.");
-				if (!this.runBroadcast()) return;
-				return this.sendReplyBox(getRoomShop(room));
+			default: 
+				var check = /add|remove|buy/, correction = '';
+				if (check.test(toId(target[0]))) {
+					var test = toId(target[0]).match(check);
+					correction = '\n(Did you mean: "' + message.replace(test, test + ',') + '")';
+				}
+				this.sendReply("'" + target[0] + "' is not a valid roomshop command. Valid roomshop commands include: add, remove, buy" + correction)
 		}
 	},
 	roomshophelp: ["This plugin allows certain rooms to have their own room shop.  Commands include...",
 		"/roomshop add, [item], [description], [price] - Adds an item to the roomshop.  Requires Room Founder.",
 		"/roomshop remove, [item] - Removes an item from the roomshop. Requires Room Founder.",
 		"/roomshop buy, [item] - Buys an item from the shop.",
-		"/roomshop - Displays a room's room shop."],
+		"/roomshop - Displays a room's room shop."
+	]
 };


### PR DESCRIPTION
Couple of things about this
1) The error was in <code>/roomshop add</code>and not <code>/roomshop buy</code> (it has nothing to do with my last PR). Not including the item description or price parameters caused the script to crash
2) Improved error messages. You should now get more meaningful error messages if you don't use the command(s) the correct way
3) Fully tested

Changes made:
1) Room founders, &, and ~ can now edit the room shop
2) Entering just <code>/roomshop</code> displays the roomshop. Entering something like <code>/roomshop potato</code> will give you an error message, stating that 'x' is an invalid command