### PR TITLE
Prevent /poof users from returning before 5 mins

### DIFF
--- a/chat-plugins/poof.js
+++ b/chat-plugins/poof.js
@@ -55,8 +55,8 @@ exports.commands = {
 		}).join('');
 
 		room.addRaw('<center><strong><font color="' + colour + '">~~ ' + Tools.escapeHTML(message) + ' ~~</font></strong></center>');
-		//user.lastPoof = Date.now();
-		//user.lastPoofMessage = message;
+		user.lastPoof = Date.now();
+		user.lastPoofMessage = message;
 		user.disconnectAll();
 	},
 

--- a/rooms.js
+++ b/rooms.js
@@ -1531,6 +1531,12 @@ let ChatRoom = (() => {
 		return message;
 	};
 	ChatRoom.prototype.onConnect = function (user, connection) {
+		if (user.lastPoof && (Date.now() - user.lastPoof < 1000 * 60 * 5) && !user.can('hotpatch')) {
+			user.send("|popup|You poof'd less than 5 minutes ago. Don't poof if you're gonna come back this soon ffs" +
+				'\n\n"' + user.lastPoofMessage + '" was your poof message, if that\'s what you came back for');
+			user.disconnectAll();
+			return;
+		}
 		let userList = this.userList ? this.userList : this.getUserList();
 		this.sendUser(connection, '|init|chat\n|title|' + this.title + '\n' + userList + '\n' + this.getLogSlice(-100).join('\n') + this.getIntroMessage(user));
 		if (this.poll) this.poll.onConnect(user, connection);


### PR DESCRIPTION
The only drawback of placing the code here is, the user can still connect to the server (but they'll be immediately disconnected). They won't be online long enough for the userlist to display their name, but their presence be logged by the last seen functions and showjoins will still report them (ex. &Siiilver joined; &Siiilver left)