### PR TITLE
Add Inverse Tiers && Previous Gens Randbats

### DIFF
--- a/config/formats.js
+++ b/config/formats.js
@@ -2571,4 +2571,154 @@ exports.Formats = [
 		debug: true,
 		ruleset: ['Pokemon', 'HP Percentage Mod', 'Cancel Mod'],
 	},
+	
+	////Gold Inverse Battles///////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////
+	{
+		name: "Inverse Random Monotype",
+		column: 2,
+		section: "Gold Inverse Tiers",
+		team: 'randomMonotype',
+		
+		ruleset: ['Pokemon', 'Same Type Clause', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		
+		searchShow: false,		
+				
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	{
+		name: "Inverse Monotype",
+		section: "Gold Inverse Tiers",
+
+		
+		ruleset: ['Pokemon', 'Standard', 'Baton Pass Clause', 'Swagger Clause', 'Same Type Clause', 'Team Preview'],
+		banlist: ['Aegislash', 'Arceus', 'Blaziken', 'Darkrai', 'Deoxys', 'Deoxys-Attack', 'Dialga', 'Genesect', 'Giratina', 'Giratina-Origin', 'Greninja', 'Groudon',
+			'Ho-Oh', 'Kyogre', 'Kyurem-White', 'Lugia', 'Mewtwo', 'Palkia', 'Rayquaza', 'Reshiram', 'Shaymin-Sky', 'Talonflame', 'Xerneas', 'Yveltal', 'Zekrom',
+			'Altarianite', 'Charizardite X', 'Damp Rock', 'Gengarite', 'Kangaskhanite', 'Lucarionite', 'Mawilite', 'Metagrossite', 'Salamencite', 'Slowbronite', 'Smooth Rock', 'Soul Dew',
+		],
+		
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	{
+	
+		name: "Inverse Random Battle",
+		section: "Gold Inverse Tiers",	
+		team: 'random',
+		
+		ruleset: ['PotD', 'Pokemon', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		
+		
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	{
+	
+		name: "Inverse Random Battle [Gen 1]",
+		section: "Gold Inverse Tiers",
+		team: 'random',
+
+		mod: 'gen1',
+		
+		ruleset: ['Pokemon', 'Standard', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+	
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	
+		{
+	
+		name: "Inverse Random Battle [Gen 2]",
+		section: "Gold Inverse Tiers",	
+		team: 'random',
+		
+		mod: 'gen2',
+		
+		ruleset: ['Pokemon', 'Standard', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	{
+		name: "Challenge Cup 1v1  [Inverse]",
+		section: "Gold Inverse Tiers",
+
+		team: 'randomCC',
+		teamLength: {
+			battle: 1,
+		},
+		
+		ruleset: ['Pokemon', 'HP Percentage Mod', 'Cancel Mod', 'Team Preview'],
+
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	{
+		name: "Hackmons Cup [Inverse]",
+		section: "Gold Inverse Tiers",
+		team: 'randomHC',
+		
+		ruleset: ['Pokemon', 'HP Percentage Mod', 'Cancel Mod'],
+						
+		onNegateImmunity: false,
+		onEffectiveness: function (typeMod, target, type, move) {
+			// The effectiveness of Freeze Dry on Water isn't reverted
+			if (move && move.id === 'freezedry' && type === 'Water') return;
+			if (move && !this.getImmunity(move, type)) return 1;
+			return -typeMod;
+		},
+	},
+	
+	//Gold Previous Gens//////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////
+	{
+		name: "[Gen 3] Random Battle",
+		col: 2,
+		section: "Gold Previous Gens",
+		
+		team: 'random',
+		ruleset: ['Pokemon', 'Standard', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+		
+		mod: 'gen3',
+	},
+	{
+		name: "[Gen 4] Random Battle",
+		section: "Gold Previous Gens",
+		
+		team: 'random',
+		ruleset: ['Pokemon', 'Standard', 'Sleep Clause Mod', 'HP Percentage Mod', 'Cancel Mod'],
+
+		mod: 'gen4',
+	},
 ];


### PR DESCRIPTION
- Inverse Added: Could honestly add more it's just a little function to add.
- Past Gens: Why doesnt main have Gen 3/4 Randbats? 
- Plans: Perhaps work on a tier that makes Super Effectives Immunities?